### PR TITLE
Fix old release tag's object reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,12 +39,17 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        git tag -a ${{ steps.last_release.outputs.date }} latest^{}
+
         gh release delete ${{ steps.last_release.outputs.date }} \
           --cleanup-tag -y 2>/dev/null || true
+
         gh release edit latest \
-          -t "Release ${{ steps.last_release.outputs.date }}" \
+          --title "Release ${{ steps.last_release.outputs.date }}" \
           --tag ${{ steps.last_release.outputs.date }} \
-          --draft=false
+          --draft=false \
+          --verify-tag
+
         git push --delete origin latest
 
       # Now we build the PDF


### PR DESCRIPTION
### Summary

Should be the final fix for release workflow. Made a small oversight in not referencing the old tag that's recreated for the previous "latest" release.

### Checklist
- [x] AC on at least 1 problem
- [x] Using tabs for indentation
- [x] Longest line at most 63 characters (with tab length 2)
- [x] Well documented
