### PR TITLE
Finished (lol) release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Retrieve last release date
       id: last_release
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       run: |
         gh release view latest --json createdAt \
           | jq -r '.createdAt' \
@@ -39,7 +39,7 @@ jobs:
     - name: Rename old release/tag
       if: steps.last_release.outputs.date
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       run: |
         gh release delete ${{ steps.last_release.outputs.date }} \
           --cleanup-tag -y 2>/dev/null || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Install pdflatex
       run: sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra
 
-      # We're going to rename the old `latest` release/tag to its creation date.
-      # First we retrieve that creation date here if possible
+    # We're going to rename the old `latest` release/tag to its creation date.
+    # First we retrieve that creation date here if possible
     - name: Retrieve last release date
       id: last_release
       env:
@@ -34,8 +34,8 @@ jobs:
           | awk -F- '{print "date="$1"/"$2"/"$3}' \
           >> $GITHUB_OUTPUT
 
-      # If we found an old release, we'll rename it to "Release <date (YYYY/MM/DD)>".
-      # We also delete the existing `latest` tag and swap it for `<date>`
+    # If we found an old release, we'll rename it to "Release <date (YYYY/MM/DD)>".
+    # We also delete the existing `latest` tag and swap it for `<date>`
     - name: Rename old release/tag
       if: steps.last_release.outputs.date
       env:
@@ -57,11 +57,11 @@ jobs:
         git tag --delete latest
         git push origin :refs/tags/latest
 
-      # Now we build the PDF
+    # Build the PDF (duh)
     - name: Build pdf
       run: make hackpack
 
-      # ...and finally tag a new release with `latest`
+    # ...and finally tag a new release with `latest`
     - name: Create release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Install pdflatex
       run: sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra
@@ -42,10 +44,9 @@ jobs:
         gh release delete ${{ steps.last_release.outputs.date }} \
           --cleanup-tag -y 2>/dev/null || true
 
-        git fetch --tags origin
         ref=$(git rev-list -n 1 latest)
         git tag ${{ steps.last_release.outputs.date }} $ref
-        git push --tags origin
+        git push origin tag ${{ steps.last_release.outputs.date }}
 
         gh release edit latest \
           --title "Release ${{ steps.last_release.outputs.date }}" \
@@ -53,7 +54,8 @@ jobs:
           --draft=false \
           --verify-tag
 
-        git push --delete origin latest
+        git tag --delete latest
+        git push origin :refs/tags/latest
 
       # Now we build the PDF
     - name: Build pdf


### PR DESCRIPTION
OK it turns out it did actually work last time, but now waiting on a permissions fix. This PR just makes sure we're not leaving around any stale tags when we rotate the latest release (nothing really necessary but wtv).

@ThomaFM need to give the Actions runner the `workflows` permission, will wait on this before merge